### PR TITLE
Got rid of putting assets in the bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-.swp
-.swo
+*.swp
+*.swo
+*.tar
 gen/*

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ To install:
 Dependencies
 
 ```
-$ go get -u github.com/jteeuwen/go-bindata/...
 $ go get github.com/go-gl/gl/v{3.2,3.3,4.1,4.4,4.5}-{core,compatibility}/gl
 $ go get github.com/go-gl/gl/v3.3-core/gl
 ```
@@ -43,6 +42,8 @@ package github.com/hurricanerix/shade/gen: cannot find package "github.com/hurri
 	/Users/hurricanerix/bin/usr/gocode/src/github.com/hurricanerix/shade/gen (from $GOPATH)
 $ go generate github.com/hurricanerix/shade/...
 $ go get github.com/hurricanerix/shade/...
+$ cd $GOPATH/src/github.com/hurricanerix/shade
+$ wget http://shade.hurricanerix.me/assets.tar
 ```
 
 To test your install:

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -1,0 +1,66 @@
+// Package archive handles reading assets that have been packed into a single
+// file.
+// TODO(hurricanerix): currently the path is hard coded, this should be changed
+//                     to make it able to ready any supported file.
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"go/build"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+// Get file from archive
+func Get(name string) ([]byte, error) {
+	d, err := importPathToDir("github.com/hurricanerix/shade")
+	if err != nil {
+		return nil, err
+	}
+
+	filepath := fmt.Sprintf("%s/assets.tar", d)
+	f, err := os.Open(filepath)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	// Create a buffer to write our archive to.
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(f)
+
+	// Open the tar archive for reading.
+	r := bytes.NewReader(buf.Bytes())
+	tr := tar.NewReader(r)
+
+	// Iterate through the files in the archive.
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+		if err != nil {
+			log.Fatalln(err)
+		}
+		if name == hdr.Name {
+			return ioutil.ReadAll(tr)
+		}
+	}
+	return nil, fmt.Errorf("Could not find '%s'", name)
+}
+
+// importPathToDir resolves the absolute path from importPath.
+// There doesn't need to be a valid Go package inside that import path,
+// but the directory must exist.
+func importPathToDir(importPath string) (string, error) {
+	p, err := build.Import(importPath, "", build.FindOnly)
+	if err != nil {
+		return "", err
+	}
+	return p.Dir, nil
+}

--- a/bindata.sh
+++ b/bindata.sh
@@ -39,15 +39,6 @@ var Version string = \"$VERSION\"\n
 var Hash string = \"$HASH\"\n
 "
 
-TMP=`go-bindata -version`
-if [ $? -ne 0 ]
-then
-  # go-bindata is required to embed assets into binary
-  echo "Downloading go-bindata"
-  go get -u github.com/jteeuwen/go-bindata/...
-fi
-
 # generate all the files we need
 mkdir -p $ROOT_PATH/gen
-go-bindata -pkg gen -ignore="/*.pyxel" -o $ROOT_PATH/gen/assets.go -prefix "../../" $ROOT_PATH/assets/
 echo -e $CODE | gofmt > $ROOT_PATH/gen/build_info.go

--- a/examples/01-basic/main.go
+++ b/examples/01-basic/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/hurricanerix/shade/camera"
 	"github.com/hurricanerix/shade/display"
 	"github.com/hurricanerix/shade/events"
+	"github.com/hurricanerix/shade/shade"
+	"github.com/hurricanerix/shade/splash"
 	"github.com/hurricanerix/shade/sprite"
 )
 
@@ -36,14 +38,22 @@ const windowHeight = 480
 
 func init() {
 	// GLFW event handling must run on the main OS thread
+	// TODO(hurricanerix): We might be able to only do this in files that
+	//                     actually handle input.
 	runtime.LockOSThread()
 }
 
 func main() {
+	shade.Run()
+
+	// TODO(hurricanerix): Everything below this should be moved to a "handler"
+	//                     that is exectured with shade.Run()
 	screen, err := display.SetMode("01-basic", windowWidth, windowHeight)
 	if err != nil {
 		log.Fatalln("failed to set display mode:", err)
 	}
+
+	splash.Main(screen)
 
 	cam, err := camera.New()
 	if err != nil {

--- a/shade/shade.go
+++ b/shade/shade.go
@@ -1,0 +1,16 @@
+package shade
+
+// Init anything needed by Shade to opperate.
+func init() {
+	// Shade needs assets.tar
+	// TODO(hurricanerix): Look for assets.tar, if not found, download it from
+	//                     http://shade.hurricanerix.me/assets.tar
+	//                     For now, we will just assume that it is in the same
+	//                     directory as the bin
+}
+
+// Run shade
+func Run() {
+	// TODO(hurricanerix): This will eventually take a "handler" which
+	//                     represents the game.
+}

--- a/sprite/sprite.go
+++ b/sprite/sprite.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/go-gl/gl/v4.1-core/gl"
 	"github.com/go-gl/mathgl/mgl32"
-	"github.com/hurricanerix/shade/gen"
+	"github.com/hurricanerix/shade/archive"
 	"github.com/hurricanerix/shade/light"
 )
 
@@ -97,7 +97,7 @@ func LoadAsset(name string) (image.Image, error) {
 		return nil, nil
 	}
 
-	imgFile, err := gen.Asset(name)
+	imgFile, err := archive.Get(name)
 	if err != nil {
 		return nil, fmt.Errorf("could not load asset %s: %v", name, err)
 	}


### PR DESCRIPTION
Instead of adding a assets.go file in gen with binary asset data in it, will read them from a tar file.